### PR TITLE
Add Algolia search engine as an option to upsert and query data

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,9 @@
     "chatgpt",
     "openai",
     "pinecone",
-    "supabase"
+    "supabase",
+    "algolia",
+    "algoliasearch"
   ],
   "homepage": "https://github.com/7-docs/7-docs",
   "bugs": "https://github.com/7-docs/7-docs/issues",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,7 @@
     "@7-docs/shared": "0.3.3",
     "@octokit/rest": "^20.0.1",
     "@supabase/supabase-js": "^2.33.1",
+    "algoliasearch": "^4.20.0",
     "cheerio": "^1.0.0-rc.12",
     "dotenv": "^16.0.3",
     "fast-glob": "^3.2.12",

--- a/packages/cli/src/cli-arguments.ts
+++ b/packages/cli/src/cli-arguments.ts
@@ -17,13 +17,13 @@ ingest
   --repo [owner/repo]     Repository to fetch file contents from (only required for --source github)
   --files [pattern]       Glob patterns for the source files (can be repeated)
   --url [url]             URL to fetch content from (use with --http, can be repeated)
-  --db [name]             Target database to store the embedding vectors. Options: pinecone, supabase (default: pinecone)
+  --db [name]             Target database to store the embedding vectors. Options: pinecone, supabase, algolia (default: pinecone)
   --namespace [name]      Namespace to store the embedding vectors
   --ignore [pattern]      Exclude files matching this pattern (can be repeated)
 
 query
   [input]                 Query input
-  --db [name]             Database to query. Options: pinecone, supabase (default: pinecone)
+  --db [name]             Database to query. Options: pinecone, supabase, algolia (default: pinecone)
   --namespace [name]      Namespace to query
   --no-stream             Don't stream the response
 

--- a/packages/cli/src/client/algolia.ts
+++ b/packages/cli/src/client/algolia.ts
@@ -39,9 +39,10 @@ export class Algolia implements VectorDatabase {
   }
 
   async upsertVectors({ vectors }: UpsertVectorOptions) {
-    const objects = vectors.map(v => ({ objectID: v.id, ...v.metadata }));
     const index = this.getIndex();
     if (!index) return 0;
+
+    const objects = vectors.map(v => ({ objectID: v.id, ...v.metadata }));
     const { objectIDs } = await index.saveObjects(objects);
     return objectIDs.length;
   }

--- a/packages/cli/src/client/algolia.ts
+++ b/packages/cli/src/client/algolia.ts
@@ -1,0 +1,61 @@
+import { MetaData } from '@7-docs/shared';
+import algoliasearch, { SearchClient } from 'algoliasearch';
+import { ALGOLIA_APP_ID, ALGOLIA_API_KEY, ALGOLIA_INDEX_NAME } from "../env.js";
+import type { UpsertVectorOptions, VectorDatabase, QueryOptions } from "../types.js";
+
+export class Algolia implements VectorDatabase {
+  appId: string;
+  apiKey: string;
+  indexName: string;
+  client?: SearchClient;
+
+  constructor() {
+    if (!ALGOLIA_APP_ID) throw new Error('Missing ALGOLIA_APP_ID environment variable');
+    if (!ALGOLIA_API_KEY) throw new Error('Missing ALGOLIA_API_KEY environment variable');
+    if (!ALGOLIA_INDEX_NAME) throw new Error('Missing ALGOLIA_INDEX_NAME environment variable');
+    this.appId = ALGOLIA_APP_ID;
+    this.apiKey = ALGOLIA_API_KEY;
+    this.indexName = ALGOLIA_INDEX_NAME;
+  }
+
+  setClient() {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const client = algoliasearch(this.appId, this.apiKey);
+    this.client = client;
+  }
+
+  getClient(): SearchClient {
+    if (!this.client) this.setClient();
+    return this.client as SearchClient;
+  }
+
+  getIndex() {
+    const client = this.getClient();
+    console.log('client', client);
+    console.log('indexName', this.indexName);
+    return client?.initIndex(this.indexName);
+  }
+
+  async upsertVectors({
+    vectors
+  }: UpsertVectorOptions) {
+    const index = this.getIndex();
+    const objects = vectors.map(v => ({ objectID: v.id, ...v.metadata }));
+    const { objectIDs } = await index.saveObjects(objects);
+    return objectIDs.length;
+  }
+
+  async query({ embedding }: QueryOptions): Promise<MetaData[]> {
+    const index = this.getIndex();
+    const { hits } = await index.search(embedding.join(','));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return hits.map((hit: any) => ({
+      filePath: hit.filePath,
+      url: hit.url,
+      content: hit.content,
+      title: hit.title,
+      ...hit.metadata
+    }));
+  }
+}

--- a/packages/cli/src/command/ingest.ts
+++ b/packages/cli/src/command/ingest.ts
@@ -1,5 +1,6 @@
 import { OpenAI } from '@7-docs/edge';
 import { CHUNK_SIZE, OPENAI_EMBEDDING_MODEL } from '@7-docs/shared';
+import { Algolia } from '../client/algolia.js';
 import { Pinecone } from '../client/pinecone.js';
 import { Supabase } from '../client/supabase.js';
 import { OPENAI_API_KEY } from '../env.js';
@@ -12,7 +13,8 @@ import type { MetaData } from '@7-docs/shared';
 
 const targets = {
   Pinecone,
-  Supabase
+  Supabase,
+  Algolia,
 };
 
 type Options = {

--- a/packages/cli/src/command/ingest.ts
+++ b/packages/cli/src/command/ingest.ts
@@ -75,7 +75,7 @@ export const ingest = async ({ source, sourceIdentifiers, ignore, repo, db, name
         const vectors = embeddings.map((values, index) => {
           const section = sections[index];
           const id = generateId(filePath + '\n' + section.content.trim());
-          const metadata: MetaData = { title, url, filePath, content: section.content, header: section.header };
+          const metadata: MetaData = { title, url, filePath, content: section.content, header: section.header, tags: section.tags };
           return { id, values, metadata };
         });
 

--- a/packages/cli/src/env.ts
+++ b/packages/cli/src/env.ts
@@ -12,3 +12,7 @@ export const SUPABASE_URL = process.env.SUPABASE_URL ?? get('env', 'SUPABASE_URL
 export const SUPABASE_API_KEY = process.env.SUPABASE_API_KEY ?? get('env', 'SUPABASE_API_KEY');
 
 export const GITHUB_TOKEN = process.env.GITHUB_TOKEN ?? get('env', 'GITHUB_TOKEN');
+
+export const ALGOLIA_APP_ID = process.env.ALGOLIA_APP_ID ?? get('env', 'ALGOLIA_APP_ID');
+export const ALGOLIA_API_KEY = process.env.ALGOLIA_API_KEY ?? get('env', 'ALGOLIA_API_KEY');
+export const ALGOLIA_INDEX_NAME = process.env.ALGOLIA_INDEX_NAME ?? get('env', 'ALGOLIA_INDEX_NAME');

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -25,6 +25,7 @@ export abstract class VectorDatabase {
 export interface DocumentSection {
   header?: string;
   content: string;
+  tags?: string[];
 }
 
 type ParsedDocument = { title?: string; sections: DocumentSection[] };


### PR DESCRIPTION
- Upsert data to Algolia search engine
- Updated `--db` help options to include `algolia` as an option
- Update meta data to include `tags`. Tags also plays a vital role when we need to search with an additional context