### PR TITLE
fix: make section available when user skip embeddings

### DIFF
--- a/packages/cli/src/command/ingest.ts
+++ b/packages/cli/src/command/ingest.ts
@@ -79,8 +79,8 @@ export const ingest = async (options: Options) => {
         const responses = await Promise.all(requests);
         const embeddings = responses.flatMap(response => response.embeddings);
 
-        const vectors = embeddings.map((values, index) => {
-          const section = sections[index];
+        const vectors = sections.map((section, index) => {
+          const values = embeddings[index] || [];
           const id = generateId(filePath + '\n' + section.content.trim());
           const metadata: MetaData = {
             title,


### PR DESCRIPTION
After introducing `skip embeddings` the embeddings have only one value of dummy embedding. So, this makes it section content to be empty within embeddings map function. So, instead of mapping through `embeddings` we can do the same with `sections` since, embeddings are created based on `sections` mappings. 